### PR TITLE
Added method to determine if cache is available for request

### DIFF
--- a/DFImageManager/Source/Core/Managing/DFImageManager.m
+++ b/DFImageManager/Source/Core/Managing/DFImageManager.m
@@ -245,6 +245,11 @@
     return [_conf.fetcher canHandleRequest:request];
 }
 
+- (BOOL)hasCacheWithRequest:(nonnull DFImageRequest *)request {
+    NSParameterAssert(request);
+    return [self _cachedResponseForRequest:request];
+}
+
 - (nullable DFImageTask *)imageTaskForResource:(nonnull id)resource completion:(nullable DFImageRequestCompletion)completion {
     NSParameterAssert(resource);
     return [self imageTaskForRequest:[DFImageRequest requestWithResource:resource] completion:completion];

--- a/DFImageManager/Source/Core/Protocols/DFImageManaging.h
+++ b/DFImageManager/Source/Core/Protocols/DFImageManaging.h
@@ -39,6 +39,10 @@ typedef void (^DFImageRequestCompletion)(UIImage *__nullable image, NSDictionary
  */
 - (BOOL)canHandleRequest:(DFImageRequest *)request;
 
+/*! Determines whether cache response is available
+ */
+- (BOOL)hasCacheWithRequest:(nonnull DFImageRequest *)request;
+
 /*! Creates an image task with a given resource. After you create the task, you must start it by calling its resume method.
  @note Creates image request with a DFImageMaximumSize, DFImageContentModeAspectFill and no options.
  @param resource The resource whose image data is to be loaded.

--- a/DFImageManager/Source/Core/Utilities/DFCompositeImageManager.m
+++ b/DFImageManager/Source/Core/Utilities/DFCompositeImageManager.m
@@ -69,6 +69,14 @@
     return DFManagerForRequest(request) != nil;
 }
 
+- (BOOL)hasCacheWithRequest:(DFImageRequest *)request {
+    id<DFImageManaging> manager = DFManagerForRequest(request);
+    if (manager) {
+        return [manager hasCacheWithRequest:request];
+    }
+    return NO;
+}
+
 - (DFImageTask *)imageTaskForResource:(id)resource completion:(DFImageRequestCompletion)completion {
     return [self imageTaskForRequest:[DFImageRequest requestWithResource:resource] completion:completion];
 }

--- a/DFImageManager/Source/Core/Utilities/DFProxyImageManager.m
+++ b/DFImageManager/Source/Core/Utilities/DFProxyImageManager.m
@@ -83,6 +83,11 @@
     return [_manager canHandleRequest:_DF_TRANSFORMED_REQUEST(request)];
 }
 
+- (BOOL)hasCacheWithRequest:(nonnull DFImageRequest *)request {
+    NSParameterAssert(request);
+    return [_manager hasCacheWithRequest:request];
+}
+
 - (DFImageTask *)imageTaskForResource:(id)resource completion:(DFImageRequestCompletion)completion {
     return [self imageTaskForRequest:[DFImageRequest requestWithResource:resource] completion:completion];
 }


### PR DESCRIPTION
I was migrating from SDWebImage and was missing a method to determine if a cache for a request already exists or not

smth. analogous to 
[SDWebImageManager.sharedManager cachedImageExistsForURL:imageURL]
