### PR TITLE
Adding Exclude for the Modular Headers

### DIFF
--- a/DFImageManager.podspec
+++ b/DFImageManager.podspec
@@ -16,17 +16,20 @@ Pod::Spec.new do |s|
     s.subspec "Core" do |ss|
         ss.source_files  = "Pod/Source/Core/**/*.{h,m}"
         ss.private_header_files = "Pod/Source/Core/Private/*.h"
+        ss.exclude_files = "Pod/Source/Core/DFImageManagerKit.h"
     end
 
     s.subspec "UI" do |ss|
         ss.ios.deployment_target = "7.0"
         ss.dependency "DFImageManager/Core"
         ss.ios.source_files = "Pod/Source/UI/**/*.{h,m}"
+        ss.ios.exclude_files = "Pod/Source/UI/DFImageManagerKit+UI.h"
     end
 
     s.subspec "NSURLSession" do |ss|
         ss.dependency "DFImageManager/Core"
         ss.source_files = "Pod/Source/NSURLSession/**/*.{h,m}"
+        ss.exclude_files = "Pod/Source/NSURLSession/DFImageManagerKit+NSURLSession.h"
     end
 
     s.subspec "AFNetworking" do |ss|
@@ -34,23 +37,27 @@ Pod::Spec.new do |s|
         ss.dependency "DFImageManager/Core"
         ss.dependency "AFNetworking/NSURLSession", "~> 2.0"
         ss.source_files = "Pod/Source/AFNetworking/**/*.{h,m}"
+        ss.exclude_files = "Pod/Source/AFNetworking/DFImageManagerKit+AFNetworking.h"
     end
 
     s.subspec "PhotosKit" do |ss|
         ss.ios.deployment_target = "7.0"
         ss.dependency "DFImageManager/Core"
         ss.source_files = "Pod/Source/PhotosKit/**/*.{h,m}"
+        ss.exclude_files = "Pod/Source/PhotosKit/DFImageManagerKit+PhotosKit.h"
     end
 
     s.subspec "GIF" do |ss|
         ss.ios.deployment_target = "7.0"
         ss.dependency "FLAnimatedImage", "~> 1.0"
         ss.source_files = "Pod/Source/GIF/**/*.{h,m}"
+        ss.exclude_files = "Pod/Source/GIF/DFImageManagerKit+GIF.h"
     end
 
     s.subspec "WebP" do |ss|
         ss.ios.deployment_target = "7.0"
         ss.dependency "libwebp"
         ss.source_files = "Pod/Source/WebP/**/*.{h,m}"
+        ss.exclude_files = "Pod/Source/WebP/DFImageManagerKit+WebP.h"
     end
 end


### PR DESCRIPTION
When using cocoapods inside another framework, you need to exclude the modular headers, as cocoa pods creates and umbrella header file for you.
